### PR TITLE
add JWT_SECRET for travis test when PR to AC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 # 設定參數(Travis CI 會按照參數分別執行)
 env:
-  - NODE_ENV=travis
+  - NODE_ENV=travis JWT_SECRET=alphacamp
 
 # 在 install 前執行的指令
 before_install:


### PR DESCRIPTION
hello @Kaminoikari 
如稍早與你討論過的，我將bracn development PR至AC upstream 進行travis測試。
PR紀錄如下，
https://github.com/ALPHACamp/twitter-api-2020/pull/384

測試檔中錯誤提示：TypeError: JwtStrategy requires a secret or key
故我在.travis.yml檔案中，將此資訊補上，
因此需要提交這個pr，修正我們目前的repo，希望可以通過測試。
再請協助確認，謝謝。